### PR TITLE
Atualização do método start

### DIFF
--- a/nbthread_spark/stream.py
+++ b/nbthread_spark/stream.py
@@ -40,7 +40,8 @@ class StreamRunner():
         self.thread.watch()
         self.query.awaitTermination()
 
-    def start(self):
+    def start(self, logger_enabled=True):
+        self.log_running = logger_enabled
         self.thread.start()
     
     def stop(self):


### PR DESCRIPTION
Receber um parâmetro adicional para dizer se a aplicação deve ou não iniciar o logger, evitando ter que adicionar o método stop_logger na linha seguinte, fazendo com que seja impresso a primeira linha do log